### PR TITLE
fix bottom nav stacking on Android

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -391,6 +391,8 @@ const styles = StyleSheet.create({
 
   bottomNav: {
     position: "absolute", left: 0, right: 0, bottom: 0,
+    zIndex: 100,
+    ...(Platform.OS === "android" ? { elevation: 10 } : {}),
     height: 66, backgroundColor: THEME.brand.glass,
     borderTopWidth: 1, borderTopColor: THEME.brand.border,
     flexDirection: "row", justifyContent: "space-around", alignItems: "center",


### PR DESCRIPTION
## Summary
- raise bottom nav z-index and add Android elevation so it layers above scroll content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c07a0a0b788323b0a10c458564e2f3