### PR TITLE
Define leaderboard handler and navigation

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -307,11 +307,15 @@ export default function Page() {
   const [wallet] = useState(initialWallet);
   const [activeLesson, setActiveLesson] = useState<any | null>(null);
   const [showSplash, setShowSplash] = useState(true);
+  const [showLeaderboard, setShowLeaderboard] = useState(false);
 
 
   // Open/close lesson
   const openLesson  = useCallback((lesson: any) => setActiveLesson(lesson), []);
   const closeLesson = useCallback(() => setActiveLesson(null), []);
+
+  const openLeaderboard = useCallback(() => setShowLeaderboard(true), []);
+  const closeLeaderboard = useCallback(() => setShowLeaderboard(false), []);
 
   // When a step completes: +1 star (capped). If done, unlock next lesson.
   const onCompleteStar = useCallback(() => {
@@ -341,9 +345,11 @@ export default function Page() {
 
   return showSplash
     ? <SplashScreen onContinue={() => setShowSplash(false)} />
-    : activeLesson
-      ? <LessonScreen lesson={activeLesson} onBack={closeLesson} onCompleteStar={onCompleteStar} />
-      : <PathScreen lessons={lessons} openLesson={openLesson} wallet={wallet} />;
+    : showLeaderboard
+      ? <LeaderboardScreen onClose={closeLeaderboard} />
+      : activeLesson
+        ? <LessonScreen lesson={activeLesson} onBack={closeLesson} onCompleteStar={onCompleteStar} />
+        : <PathScreen lessons={lessons} openLesson={openLesson} wallet={wallet} openLeaderboard={openLeaderboard} />;
 
 }
 


### PR DESCRIPTION
## Summary
- add `openLeaderboard` and `closeLeaderboard` handlers
- pass leaderboard handler to `PathScreen`
- render `LeaderboardScreen` when trophy icon tapped

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c083680cb88323b05b540da8b8f2f5