### PR TITLE
fix: remove glow box from login title

### DIFF
--- a/login.html
+++ b/login.html
@@ -29,8 +29,8 @@ body{
 .sky-neon{
   position:fixed; z-index:1000;       /* front-most */
   top:calc(env(safe-area-inset-top) + 10vh); left:50%; transform:translateX(-50%);
-  width:95vw; text-align:center; pointer-events:none;
-  mix-blend-mode:screen;
+  /* shrink to content so glow doesn't highlight a wide box */
+  width:auto; text-align:center; pointer-events:none;
 }
 .sky-neon .txt{
   font: 900 clamp(44px,9vw,140px)/1.02 "Segoe UI",system-ui,sans-serif;


### PR DESCRIPTION
## Summary
- shrink login neon overlay to text width
- eliminate mix-blend-mode that caused full-screen glow box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ddebbf4083239506fa1b79be8a9f