### PR TITLE
Refine navbar icons and blank tab screens

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -407,21 +407,18 @@ function LeaderboardScreen({ onClose }: { onClose: () => void }) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-function MessagesScreen() {
+function BlankScreen() {
   return (
     <SafeAreaView style={styles.screen}>
-      <Text style={{ color: THEME.text.primary, margin: 16, fontSize: 18 }}>Messages</Text>
+      <View style={styles.topBar} />
     </SafeAreaView>
   );
-}
-
-function MoviesScreen() {
-  return <SafeAreaView style={styles.screen} />;
 }
 
 function RssFeedScreen() {
   return (
     <SafeAreaView style={styles.screen}>
+      <View style={styles.topBar} />
       <WebView
         source={{ uri: "https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml" }}
         style={{ flex: 1 }}
@@ -469,7 +466,7 @@ export default function Page() {
   const [activeLesson, setActiveLesson] = useState<any | null>(null);
   const [showLogin, setShowLogin] = useState(true);
   const [showLeaderboard, setShowLeaderboard] = useState(false);
-  const [tab, setTab] = useState<'home' | 'messages' | 'rss' | 'movies'>('home');
+  const [tab, setTab] = useState<'home' | 'messages' | 'rss' | 'movies' | 'path'>('path');
   const insets = useSafeAreaInsets();
 
 
@@ -510,10 +507,9 @@ export default function Page() {
   if (showLogin) content = <LoginScreen onProceed={() => setShowLogin(false)} />;
   else if (showLeaderboard) content = <LeaderboardScreen onClose={closeLeaderboard} />;
   else if (activeLesson) content = <LessonScreen lesson={activeLesson} onBack={closeLesson} onCompleteStar={onCompleteStar} />;
-  else if (tab === 'messages') content = <MessagesScreen />;
   else if (tab === 'rss') content = <RssFeedScreen />;
-  else if (tab === 'movies') content = <MoviesScreen />;
-  else content = <PathScreen lessons={lessons} openLesson={openLesson} wallet={wallet} />;
+  else if (tab === 'path') content = <PathScreen lessons={lessons} openLesson={openLesson} wallet={wallet} />;
+  else content = <BlankScreen />;
 
   return (
     <>
@@ -529,7 +525,8 @@ export default function Page() {
             { icon: '🏠', action: () => setTab('home') },
             { icon: '🎥', action: () => setTab('movies') },
             { icon: '🏆', action: openLeaderboard },
-            { icon: '🆕', action: () => setTab('rss') },
+            { icon: '🎒', action: () => setTab('path') },
+            { icon: '📰', action: () => setTab('rss') },
             { icon: '💬', action: () => setTab('messages') },
           ].map((item, i) => (
             <TouchableOpacity key={i} style={styles.navBtn} onPress={item.action}>


### PR DESCRIPTION
## Summary
- add blank screen component and use it for home, movies, and messages tabs
- wire backpack icon to learning path and switch fish tab to article icon
- show learning path by default and keep leaderboard access via trophy
- ensure blank and RSS tabs include top bar for consistent theming

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2798d88508323b9b218c122e32c40