### PR TITLE
feat: enable tap-to-enter on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Everyday Winners Mobile App
 
-Neon City login screen (HTML via WebView) opens first, then routes to the dashboard when the **Enter City** button is tapped.
+Neon City login screen (HTML via WebView) opens first, then routes to the dashboard when the screen is tapped.
 
 ## Prereqs
 - Node 18+

--- a/index.tsx
+++ b/index.tsx
@@ -259,12 +259,12 @@ function LoginScreen({ onProceed }: { onProceed: () => void }) {
   // WebView doesn't run on web; show a fallback screen
   if (Platform.OS === "web") {
     return (
-      <View style={styles.webLogin}>
+      <TouchableOpacity style={styles.webLogin} onPress={onProceed} activeOpacity={1}>
         <Text style={styles.webLoginTitle}>Winners University</Text>
-        <TouchableOpacity style={styles.cta} onPress={onProceed}>
+        <View style={styles.cta}>
           <Text style={styles.ctaText}>Enter City</Text>
-        </TouchableOpacity>
-      </View>
+        </View>
+      </TouchableOpacity>
     );
   }
   return (

--- a/login.html
+++ b/login.html
@@ -396,13 +396,16 @@ for(let i=0;i<NUM_CARS;i++){
 }
 requestAnimationFrame(tick);
 
-document.getElementById('login-btn').addEventListener('click', () => {
+function proceed() {
   if (window.ReactNativeWebView) {
     window.ReactNativeWebView.postMessage('login');
   } else {
     alert('Proceeding to dashboard...');
   }
-});
+}
+
+// Allow tapping anywhere on the screen to continue
+document.addEventListener('click', proceed, { once: true });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow tapping anywhere on HTML login screen to proceed
- make web fallback screen full-screen pressable
- update docs for tap-based login

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c27dbf0fd48323848794cee64c2526