### PR TITLE
Allow cars to pass without overlapping

### DIFF
--- a/login.html
+++ b/login.html
@@ -365,7 +365,7 @@ function tick(t){
     else { groups.push({mid:c.yBottom, list:[c]}); }
   }
 
-  // within each lane group, enforce spacing by pushing forward cars smoothly
+  // within each lane group, keep cars separated while allowing overtaking
   for(const g of groups){
     const lane = g.list.sort((a,b)=>a.x-b.x); // left->right
     for(let i=0;i<lane.length-1;i++){
@@ -374,9 +374,14 @@ function tick(t){
       const minGap = Math.max(rear.w, front.w)*0.6 + GAP_EXTRA_PX;
       const overlap = (rear.x + minGap) - front.x;
       if(overlap > 0){
-        // push front ahead smoothly, and also let its speed catch up
-        front.x += overlap * PUSH_STRENGTH;
-        front.speed = Math.max(front.speed, rear.speed*0.95);
+        if(rear.speed > front.speed){
+          // let the faster rear car pass the slower front car
+          rear.x = front.x + minGap;
+        } else {
+          // push front ahead smoothly, and also let its speed catch up
+          front.x += overlap * PUSH_STRENGTH;
+          front.speed = Math.max(front.speed, rear.speed*0.95);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adjust car spacing logic to let faster cars overtake slower ones without overlapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c282364b9483239d7d6068c19a90e5