### PR TITLE
feat: add dashboard home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Neon City login screen (HTML via WebView) opens first, then routes to the dashboard when the screen is tapped.
 
 ## Features
+- Home dashboard shows coin, flame, gem, and energy balances at a glance.
 - Bottom navigation includes a **Messages** tab with an RSS-style feed, quick contact buttons (email & call), and four preset questions for fast outreach.
 
 ## Prereqs

--- a/index.tsx
+++ b/index.tsx
@@ -439,6 +439,36 @@ function BlankScreen() {
   return <SafeAreaView style={styles.screen} />;
 }
 
+function DashboardScreen({ wallet }: { wallet: typeof initialWallet }) {
+  return (
+    <SafeAreaView style={styles.screen}>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <Text style={styles.sectionSubtitle}>Dashboard</Text>
+        <View style={styles.dashboardRow}>
+          <View style={styles.dashboardCard}>
+            <Text style={styles.dashboardValue}>{wallet.coins}</Text>
+            <Text style={styles.dashboardLabel}>Coins</Text>
+          </View>
+          <View style={styles.dashboardCard}>
+            <Text style={styles.dashboardValue}>{wallet.flames}</Text>
+            <Text style={styles.dashboardLabel}>Flames</Text>
+          </View>
+        </View>
+        <View style={styles.dashboardRow}>
+          <View style={styles.dashboardCard}>
+            <Text style={styles.dashboardValue}>{wallet.gems}</Text>
+            <Text style={styles.dashboardLabel}>Gems</Text>
+          </View>
+          <View style={styles.dashboardCard}>
+            <Text style={styles.dashboardValue}>{wallet.energy}</Text>
+            <Text style={styles.dashboardLabel}>Energy</Text>
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
 function MessagesScreen() {
   const [messages, setMessages] = useState([
     { id: 1, title: 'Welcome to Everyday Winners!', read: false },
@@ -596,7 +626,7 @@ export default function Page() {
   const [showLogin, setShowLogin] = useState(true);
   const [showLeaderboard, setShowLeaderboard] = useState(false);
   const [showStats, setShowStats] = useState(false);
-  const [tab, setTab] = useState<'home' | 'messages' | 'rss' | 'movies' | 'path'>('path');
+  const [tab, setTab] = useState<'home' | 'messages' | 'rss' | 'movies' | 'path'>('home');
   const insets = useSafeAreaInsets();
 
 
@@ -649,6 +679,7 @@ export default function Page() {
   else if (showLeaderboard) content = <LeaderboardScreen onContinue={goToStats} />;
   else if (showStats) content = <StatsScreen onClose={closeStats} />;
   else if (activeLesson) content = <LessonScreen lesson={activeLesson} onBack={closeLesson} onCompleteStar={onCompleteStar} />;
+  else if (tab === 'home') content = <DashboardScreen wallet={wallet} />;
   else if (tab === 'messages') content = <MessagesScreen />;
   else if (tab === 'rss') content = <RssFeedScreen />;
   else if (tab === 'path') content = <PathScreen lessons={lessons} openLesson={openLesson} wallet={wallet} />;
@@ -791,6 +822,18 @@ const styles = StyleSheet.create({
   },
   messageUnread: { backgroundColor: THEME.brand.glass },
   messageText: { color: THEME.text.primary },
+  dashboardRow: { flexDirection: 'row', justifyContent: 'space-between', gap: 12, marginTop: 16 },
+  dashboardCard: {
+    flex: 1,
+    backgroundColor: THEME.brand.glass,
+    borderColor: THEME.brand.border,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+  },
+  dashboardValue: { color: THEME.text.primary, fontSize: 20, fontWeight: '800' },
+  dashboardLabel: { color: THEME.text.secondary, marginTop: 4, fontWeight: '600' },
   link: { color: THEME.brand.teal, fontWeight: "700", fontSize: 16 },
   questionBtn: {
     backgroundColor: THEME.brand.glass,


### PR DESCRIPTION
## Summary
- add DashboardScreen to show wallet balances on home tab
- default to home tab after login
- document new dashboard feature in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c28b8ea6408323b4fc382d16e8b6c0