### PR TITLE
feat: add multi-bureau scores and document uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Neon City login screen (HTML via WebView) opens first, then routes to the dashboard when the screen is tapped.
 
 ## Features
-- Home dashboard greets the user by name, shows deletions and current credit score, lets you upload a credit report HTML file, and displays items from that report along with coin, flame, gem, and energy balances.
+- Home dashboard greets the user by name, shows scores from all three bureaus, lets you upload a credit report HTML file, and renders parsed tradelines as cards.
+- Upload buttons accept ID and proof-of-residency documents.
+- Recommended actions appear centered beneath tradelines for quick next steps.
 - Bottom navigation includes a **Messages** tab with an RSS-style feed, quick contact buttons (email & call), and four preset questions for fast outreach. Message threads stay hidden until a question is picked and each question keeps its own conversation.
 
 ## Prereqs


### PR DESCRIPTION
## Summary
- show Experian, Equifax, and TransUnion scores on dashboard
- allow uploading ID and proof of residency documents
- parse uploaded report HTML into tradeline cards with centered recommended actions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3257101d083238d64c8db52667272